### PR TITLE
only build to us.gcr.io registry

### DIFF
--- a/cloud_builder.yaml
+++ b/cloud_builder.yaml
@@ -6,23 +6,11 @@ timeout: 1200s
 steps:
   - id: cos-gpu-installer
     name: "gcr.io/cloud-builders/docker"
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/cos-gpu-installer:latest", "."]
+    args: ["build", "-t", "us.gcr.io/$PROJECT_ID/cos-gpu-installer:latest", "."]
     dir: cos-gpu-installer-docker
     waitFor: ["-"]
-
-  - id: us-cos-gpu-installer
-    name: "gcr.io/cloud-builders/docker"
-    args: [
-      "build",
-      "-t", "us.gcr.io/$PROJECT_ID/cos-gpu-installer:latest",
-      "--cache-from", "gcr.io/$PROJECT_ID/cos-gpu-installer:latest",
-      "."]
-    dir: cos-gpu-installer-docker
-    waitFor:
-      - cos-gpu-installer
 
 logsBucket: fathom-containers-cloud-build-logs-36tugmiz
 
 images:
-  - gcr.io/$PROJECT_ID/cos-gpu-installer
   - us.gcr.io/$PROJECT_ID/cos-gpu-installer


### PR DESCRIPTION
**ASANA TASK LINK:**
https://app.asana.com/0/1140153117941490/1155931194339842/f

**DESIGN DOC LINK:**
https://docs.google.com/document/d/1gox2x_WggIn4cUNirgjQdrmYehd-x6QMc6eE8EsZkH0/edit?usp=sharing

DETAILS
-------
after we've changed all references to us.gcr.io, we will stop building the co-gpu-installer image to gcr.io.

CHECK LIST
----------
**TEST PLAN:**
- [x] cos-gpu-installer image no longer built to gcr.io registry

**DID I MATERIALLY UPDATE DOCKERFILE(S)?:**
N

**RISK & IMPACT ASSESSMENT:**
minimal risk