### PR TITLE
Extract all items from package to avoid problems with hard links

### DIFF
--- a/cos-gpu-installer-docker/entrypoint.sh
+++ b/cos-gpu-installer-docker/entrypoint.sh
@@ -328,12 +328,7 @@ install_cross_toolchain_pkg() {
       return ${RETCODE_ERROR}
     fi
 
-    # Don't unpack Rust toolchain elements because they are not needed and they
-    # use a lot of disk space.
-    tar xf "${pkg_name}" \
-      --exclude='./usr/lib64/rustlib*' \
-      --exclude='./lib/librustc*' \
-      --exclude='./usr/lib64/librustc*'
+    tar xf "${pkg_name}"
     rm "${pkg_name}"
     popd
   fi


### PR DESCRIPTION
Task: https://app.asana.com/0/1142555270241225/1201639048348826/f

TLDR: picky extraction is failing if there are hard links in the archive. We need to extract all contents. More context in the task, see my comment