### PR TITLE
Cat nvidia error log

### DIFF
--- a/cos-gpu-installer-docker/entrypoint.sh
+++ b/cos-gpu-installer-docker/entrypoint.sh
@@ -406,7 +406,7 @@ configure_nvidia_installation_dirs() {
   update_container_ld_cache
 
   # Install an exit handler to cleanup the overlayfs mount points.
-  trap "{ umount /lib/modules/\"$(uname -r)\"/video; umount -fl /usr/lib/x86_64-linux-gnu ; umount /usr/bin; }" EXIT
+  trap "{ umount /lib/modules/\"$(uname -r)\"/video; umount -fl /usr/lib/x86_64-linux-gnu ; umount /usr/bin; cat /var/log/nvidia-installer.log;}" EXIT
   popd
 }
 


### PR DESCRIPTION
[Nvidia driver installation failing in hi-legend-us](https://app.asana.com/0/1206866611805847/1207827309633423)
Temporarily cat the nvidia error log before exit to debug driver installation failures